### PR TITLE
Added the ability to set the index link

### DIFF
--- a/src/main/resources/js/toc.js
+++ b/src/main/resources/js/toc.js
@@ -16,7 +16,13 @@ if (toctitle != null) {
     });
     if (!path.endsWith("index.html") && !path.endsWith("/")) {
         var link = document.createElement("a");
-        link.setAttribute("href", "index.html");
+        if (document.getElementById('index-link')) {
+          indexLinkElement = document.querySelector('#index-link > p > a');
+          linkHref = indexLinkElement.getAttribute("href");
+          link.setAttribute("href", linkHref);
+        } else {
+          link.setAttribute("href", "index.html");
+        }
         link.innerHTML = "<span><i class=\"fa fa-chevron-left\" aria-hidden=\"true\"></i></span> Back to index";
         var block = document.createElement("div");
         block.setAttribute('class', 'back-action');

--- a/src/main/sass/spring/_asciidoctor.scss
+++ b/src/main/sass/spring/_asciidoctor.scss
@@ -1642,3 +1642,7 @@ b.conum * {
 .is-collapsed {
   max-height: 0
 }
+
+#index-link {
+  display: none
+}


### PR DESCRIPTION
If you add a role with an ID of index-link, the href that you specify below that role ID becomes the link in the "Back to index" link in the table of contents.

The inserted role has the following form:

[#index-link]
https://spring.io

The URL can be any valid URL, whether relative or absolute.

This fix meets a need that Oleg Zhurakousky identified.