### PR TITLE
URL Cleanup

### DIFF
--- a/spring-style-guide/spring-style-guide.adoc
+++ b/spring-style-guide/spring-style-guide.adoc
@@ -17,7 +17,7 @@ Spring.
 
 NOTE: This guide is not meant to be an explanation of how Asciidoc works. For the syntax
 of how to create any particular construct in Asciidoc, see the
-http://asciidoctor.org/docs/user-manual/[Asciidoc User Manual].
+https://asciidoctor.org/docs/user-manual/[Asciidoc User Manual].
 
 This style guide covers the following topics:
 

--- a/src/main/resources/js/highlight/styles/dracula.min.css
+++ b/src/main/resources/js/highlight/styles/dracula.min.css
@@ -7,7 +7,7 @@ https://github.com/zenorocha/dracula-theme
 Copyright 2015, All rights reserved
 
 Code licensed under the MIT license
-http://zenorocha.mit-license.org
+https://zenorocha.mit-license.org/
 
 @author Éverton Ribeiro <nuxlli@gmail.com>
 @author Zeno Rocha <hi@zenorocha.com>

--- a/src/main/resources/js/highlight/styles/monokai-sublime.min.css
+++ b/src/main/resources/js/highlight/styles/monokai-sublime.min.css
@@ -1,6 +1,6 @@
 /*
 
-Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-license.org/
+Monokai Sublime style. Derived from Monokai by noformnocontent https://nn.mit-license.org/
 
 */
 

--- a/src/main/resources/js/highlight/styles/monokai.min.css
+++ b/src/main/resources/js/highlight/styles/monokai.min.css
@@ -1,5 +1,5 @@
 /*
-Monokai style - ported by Luigi Maselli - http://grigio.org
+Monokai style - ported by Luigi Maselli - https://grigio.org
 */
 
 .hljs {

--- a/src/test/resources/index.adoc
+++ b/src/test/resources/index.adoc
@@ -158,7 +158,7 @@ ____
 A person who never made a mistake never tried anything new.
 ____
 
-[quote, Charles Lutwidge Dodgson, 'Mathematician and author, also known as http://en.wikipedia.org/wiki/Lewis_Carroll[Lewis Carroll]']
+[quote, Charles Lutwidge Dodgson, 'Mathematician and author, also known as https://en.wikipedia.org/wiki/Lewis_Carroll[Lewis Carroll]']
 ____
 If you don't know where you are going, any road will get you there.
 ____


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://livereload.com/ (200) with 1 occurrences could not be migrated:  
   ([https](https://livereload.com/) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://zenorocha.mit-license.org (301) with 1 occurrences migrated to:  
  https://zenorocha.mit-license.org/ ([https](https://zenorocha.mit-license.org) result NullPointerException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org/docs/user-manual/ with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/user-manual/ ([https](https://asciidoctor.org/docs/user-manual/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2000/svg with 1 occurrences