### PR TITLE
Keep style for <code> tags consistent in tableblock

### DIFF
--- a/src/main/sass/spring/_asciidoctor.scss
+++ b/src/main/sass/spring/_asciidoctor.scss
@@ -1099,7 +1099,7 @@ tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p {
   font-weight: bold;
 }
 
-p.tableblock > code:only-child {
+p.tableblock > code {
   background: none;
   padding: 0;
 }


### PR DESCRIPTION
Hi,

this is a PR needed in order to fix https://github.com/spring-projects/spring-boot/pull/16480 in Spring-Boot. See the issue for more information.

Cheers,
Christoph