### PR TITLE
Tables that should be full-width are not when using Asciidoctor 1.5.7+

### DIFF
--- a/src/main/sass/spring/_asciidoctor.scss
+++ b/src/main/sass/spring/_asciidoctor.scss
@@ -110,7 +110,7 @@ object, svg {
   margin-right: auto;
 }
 
-.spread {
+.spread, .stretch {
   width: 100%;
 }
 


### PR DESCRIPTION
Previously, Asciidoctor used spread for a full-width table but this [changed](https://github.com/asciidoctor/asciidoctor/issues/2589) to stretch in 1.5.7. As a result, a table that should be full-width is not when using `spring.css` with Asciidoctor 1.5.7+.

This PR updates the CSS to apply 100% width to `.stretch`. This is done in addition to `.spread` to avoid breaking backwards compatibility.