### PR TITLE
Remove overflow-x settings to hide scrollbars

### DIFF
--- a/src/main/sass/spring/_asciidoctor.scss
+++ b/src/main/sass/spring/_asciidoctor.scss
@@ -1032,7 +1032,6 @@ table.pyhltable .linenodiv {
 table.tableblock {
   max-width: 100%;
   border-collapse: separate;
-  overflow-x: scroll;
   display: block;
 }
 
@@ -1615,7 +1614,6 @@ b.conum * {
   margin: 30px 0;
   width: auto;
   border-radius: 4px;
-  overflow-x: auto;
   &.important {
     border-left: 0px solid #e20000;
     background-color: #f9ebeb;

--- a/src/main/sass/spring/_layout.scss
+++ b/src/main/sass/spring/_layout.scss
@@ -269,7 +269,6 @@ h6 {
 pre.highlight {
   padding: 20px;
   border: 1px solid #d9d9d9;
-  overflow-x: scroll;
   code {
     color: #222;
   }


### PR DESCRIPTION
Upgrade the stylesheet so that overflow-x settings are not used. These
cause odd visual artifacts on a Mac when "show scrollbars" is set to
"always".

Closes gh-49