### PR TITLE
Reduce left indent for code blocks.

### DIFF
--- a/src/main/sass/spring/_asciidoctor.scss
+++ b/src/main/sass/spring/_asciidoctor.scss
@@ -828,7 +828,7 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p {
   //-webkit-border-radius: 4px;
   //border-radius: 4px;
   //word-wrap: normal;
-  padding: 1em 1.5rem;
+  padding: 1em 0.75rem;
   font-size: 0.8125em;
 }
 


### PR DESCRIPTION
Helps to waste precious screen estate, especially on mobile views.

Before
<img width="518" alt="before" src="https://user-images.githubusercontent.com/128577/181832058-5f0429de-805a-40ed-9138-5aa9d7bfad2f.png">

After
<img width="518" alt="after" src="https://user-images.githubusercontent.com/128577/181832013-2d2488e3-3ab1-451f-88b5-5acbc1482ece.png">
0